### PR TITLE
#32 Tela de Cadastro de Grupos de itens + outras mudanças

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7694,9 +7694,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
         }
       }
     },

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -3,7 +3,7 @@
     --main-bg-color: #26a69a;
 }
 
-nav {
+.main-nav {
     background-color: var(--main-bg-color);
     padding-left: 10px;
 }

--- a/app/src/components/NavBar.js
+++ b/app/src/components/NavBar.js
@@ -12,7 +12,7 @@ const NavBar = ({
                     items = [],
                 }) => {
     return (
-        <nav>
+        <nav class="main-nav">
             <div className="nav-wrapper">
                 <a href="#" className="brand-logo">
                     <img src={logo} alt="Logo" width="150" height="60"></img>

--- a/app/src/components/SideBar.js
+++ b/app/src/components/SideBar.js
@@ -28,6 +28,7 @@ const SideBar = (props) => {
                 </li>
                 <li><a href="#!"><i className="material-icons">cloud</i>First Link With Icon</a></li>
                 <li><a href="#!">Second Link</a></li>
+                <li><a href="/itemgroups">Grupos de Itens</a></li>
                 <li>
                     <div className="divider"></div>
                 </li>

--- a/app/src/components/commons/Button.js
+++ b/app/src/components/commons/Button.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import "../css/Button.css";
 
 const Button = ({
                     label = '',

--- a/app/src/components/css/Breadcrumb.css
+++ b/app/src/components/css/Breadcrumb.css
@@ -1,0 +1,15 @@
+.breadcrumb-nav {
+    background: transparent;
+    box-shadow: none;
+    height: 40px;
+    line-height: 40px;
+}
+
+.breadcrumb {
+    color: rgb(68, 49, 49);
+}
+
+.breadcrumb:hover {
+    color: rgb(77, 97, 82);
+    text-decoration: underline;
+}

--- a/app/src/components/css/Button.css
+++ b/app/src/components/css/Button.css
@@ -1,0 +1,3 @@
+Button {
+    margin: 10px;
+}

--- a/app/src/components/css/Form.css
+++ b/app/src/components/css/Form.css
@@ -1,0 +1,3 @@
+#form-box {
+    background: linear-gradient(to right, rgb(235, 237, 240), rgb(227, 243, 238));
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -6,10 +6,6 @@ body {
     background: linear-gradient(to right, rgb(172, 240, 217), rgb(221, 218, 218));
 }
 
-#form-box {
-    background: linear-gradient(to right, rgb(235, 237, 240), rgb(227, 243, 238));
-}
-
 code {
     font-family: monospace;
 }

--- a/app/src/pages/admin/CreateUserPage.js
+++ b/app/src/pages/admin/CreateUserPage.js
@@ -5,6 +5,8 @@ import Field from "components/form/Field";
 import FormButton from "components/form/FormButton";
 import Api from "service/Api";
 import UiMsg from "components/commons/UiMsg";
+import "../../components/css/Breadcrumb.css";
+import "../../components/css/Form.css";
 
 const UserSchema = yup(yup => {
     return yup.object().shape({
@@ -60,10 +62,19 @@ const UserForm = () => {
 
 const CreateUserPage = (props) => {
     return (
-        <div>
-            CRIAÇÃO DE USUÁRIOS
-            <UserForm/>
-        </div>
+        <React.Fragment>
+            <nav class="breadcrumb-nav">
+                <div class="nav-wrapper">
+                    <div class="col s12">
+                        <a href="/home" class="breadcrumb">Home</a>
+                        <a href="/admin/user/create" class="breadcrumb">Criar Usuários</a>
+                    </div>
+                </div>
+            </nav>
+            <div>
+                <UserForm />
+            </div>
+        </React.Fragment>
     )
 };
 

--- a/app/src/pages/private/ItemGroups.js
+++ b/app/src/pages/private/ItemGroups.js
@@ -1,0 +1,108 @@
+import React from "react";
+import { yup } from "components/form/customYup";
+import { Form, Formik } from "formik";
+import Field from "components/form/Field";
+import FormButton from "components/form/FormButton";
+import Button from "../../components/commons/Button";
+import Icon from "../../components/commons/Icon";
+import Api from "service/Api";
+import UiMsg from "components/commons/UiMsg";
+import "../../components/css/Breadcrumb.css";
+import "../../components/css/Form.css";
+
+const ItemGroupSchema = yup(yup => {
+    return yup.object().shape({
+        descricao: yup.string().required().default('')
+    })
+});
+
+const ItemGroupsForm = () => {
+
+    // Ação do botão aqui
+    const createItemGroup = async (values, actions) => {
+
+    };
+
+    return (
+        <div class="valign-wrapper row login-box">
+            <div id="form-box" class="col card hoverable s12 pull-s1 m6 pull-m3 14 pull-14">
+                <Formik
+                    initialValues={ItemGroupSchema.default()}
+                    onSubmit={createItemGroup}>
+                    <Form className="col s12">
+                        <div class="card-content">
+                            <span class="card-title center-align">
+                                Cadastro de Grupos de Itens</span>
+                            <div class="row">
+                                <div class="input-field col s12">
+                                    <Field title="Descrição" type="text" name="descricao" />
+                                </div>
+                                <Field title="itemGroupId" type="hidden" name="itemGroupId" />
+                            </div>
+                            <div class="card-action center-align">
+                                <FormButton type="submit">Salvar</FormButton>
+                                <FormButton type="reset">Limpar</FormButton>
+                            </div>
+                        </div>
+                    </Form>
+                </Formik>
+            </div>
+        </div>
+    );
+};
+
+// Necessário preencher a tabela com dados vindos do banco e configurar ações dos botões Editar/Excluir
+const ItemGroupsTable = () => {
+    return (
+        <div class="container">
+            <div class="row">
+                <div class="col s12">
+                    <table class="striped teal lighten-2 left-aling">
+                        <thead>
+                            <tr>
+                                <th>Descrição</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Teste</td>
+                                <td>
+                                    <Button onClick="#">
+                                        <Icon icon="edit" size="medium"></Icon>
+                                    </Button>
+                                    <Button onClick="#">
+                                        <Icon icon="cancel" size="medium"></Icon>
+                                    </Button>
+                                </td>
+                            </tr>      
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const ItemGroups = (props) => {
+    return (
+        <React.Fragment>
+            <nav class="breadcrumb-nav">
+                <div class="nav-wrapper">
+                    <div class="col s12">
+                        <a href="/home" class="breadcrumb">Home</a>
+                        <a href="/itemgroups" class="breadcrumb">Grupos de Itens</a>
+                    </div>
+                </div>
+            </nav>
+            <div>
+                <ItemGroupsForm />
+            </div>
+            <div>
+                <ItemGroupsTable />
+            </div>
+        </React.Fragment>
+    )
+};
+
+export default ItemGroups;

--- a/app/src/pages/private/PrivateRoutes.js
+++ b/app/src/pages/private/PrivateRoutes.js
@@ -1,10 +1,15 @@
 import {PrivateRoute} from 'router/Route';
-import Home from "pages/private/HomePage";
+import Home from 'pages/private/HomePage';
+import ItemGroups from 'pages/private/ItemGroups';
 
 const routes = [
     {
         path: '/home',
         component: Home
+    },
+    {
+        path: '/itemgroups',
+        component: ItemGroups
     }
 ];
 


### PR DESCRIPTION
- Criada estrutura de breadcrumb, adicionada às páginas já existentes, cadastro de usuários e de grupos de itens. A estrutura deverá ser reaproveitada nas demais páginas onde for necessário.
- Criada classe ItemGroups.js contendo breadcrumb, formulário e tabela de teste. Ainda é necessário configurar o botão de cadastro, popular tabela com os dados vindos do backend e configurar botões de ação da tabela (editar e remover).
- Criada pasta para agrupar os documentos de CSS dentro da pasta components. Arquivos App.css e index.css ficam valendo apenas para a estilização global, demais configurações foram movidas para arquivos separados dentro da nova pasta criada.
- Adicionado atalho na SideBar e rota para o cadastro de grupos de itens.
